### PR TITLE
Fix: Replace br tag with newline and remove html tags when creating ics file

### DIFF
--- a/addon/components/types/ical-cal.js
+++ b/addon/components/types/ical-cal.js
@@ -26,6 +26,9 @@ export default Base.extend({
     if (!moment.isMoment(endTime)) {
       endTime = moment(endTime);
     }
+    if (description) {
+      description = description.replace(/<br\s*\/?>/ig, "\\n").replace(/<(?:.|\n)*?>/gm, '');
+    }
     let start = startTime.format('YYYYMMDDTHHmmss');
     let end = endTime.format('YYYYMMDDTHHmmss');
 


### PR DESCRIPTION
I tried to add HTML support for the .ics file in the description field but looks like this is something not trivial and even if can work for outlook adding an `ALTREP` attribute, it is not a final solution because it can fail on different versions of Outlook and for other apps like Apple Calendar will not work. Like the goal is to support different calendar services I found that newlines are accepted in the description field so spaces between lines and a nice format can be added. 

This PR replace any `<br>` tag in the description with `\n` and then removes all the HTML tags. 

**This is how an event looks in Apple Calendar with this solution.**
![image](https://user-images.githubusercontent.com/278589/41871845-c0153af8-7885-11e8-9562-997443fbd885.png)

**Instead of:**
![image](https://user-images.githubusercontent.com/278589/41871985-31407242-7886-11e8-93d9-de481b00d661.png)
