### PR TITLE
refactor: Fix hasBlock deprecation

### DIFF
--- a/addon/templates/components/calendar-button.hbs
+++ b/addon/templates/components/calendar-button.hbs
@@ -1,6 +1,6 @@
 
 
-{{#if hasBlock}}
+{{#if (has-block)}}
   {{yield
     (hash
       google=(component "types/google-cal" event=event onClick=(action "onClick"))


### PR DESCRIPTION
## Changes

- Fixed `has-block` deprecation in scope of Ember upgrade.

https://deprecations.emberjs.com/id/has-block-and-has-block-params